### PR TITLE
change structure of test result

### DIFF
--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,9 +1,9 @@
 
-describe('#binaryMatch', function() {
+describe('#buildHistogram', function() {
 	let magazine = ["h", "e", "r", "e", "a", "r", "e", "s", "o", "m",
 	"e", "n", "i", "c", "e", "c", "l", "o", "t", "h", "e", "s", "t"]
 	it("collects assigns each letter as a key and the number of occurrences as the value", function() {
-		let result = [{"a": 1}, {"c": 2}, {"e": 6}, {"h": 2}, {"i": 1}, {"l": 1}, {"m": 1}, {"n": 1}, {"o": 2}, {"r": 2}, {"s": 2}, {"t": 2}]
+		let result = {"a": 1, "c": 2, "e": 6, "h": 2, "i": 1, "l": 1, "m": 1, "n": 1, "o": 2, "r": 2, "s": 2, "t": 2}
 		let functionResult = buildHistogram(magazine)
 		expect(functionResult["e"]).toEqual(6)
 		expect(functionResult["h"]).toEqual(2)


### PR DESCRIPTION
This PR modifies two pieces of the test.
1. It changes the function name in the describe block so it accurately identifies the name of the method being tested.
2. It modifies the data structure of the `result` variable from an array of hashes, to a single hash with key-value pairs.  Per the lesson, this is the preferred data structure for a histogram and it makes more sense from a Big O perspective to have an O(1) lookup here instead of O(n) speed the array of hashes provides.